### PR TITLE
Fix install_n8n.sh path detection

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 sudo apt update && sudo apt install -y ca-certificates curl gnupg lsb-release
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
@@ -10,7 +11,8 @@ sudo usermod -aG docker $USER
 newgrp docker
 sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
-cd ~/n8n_oci
-mkdir n8n_data
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+cd "$SCRIPT_DIR/.."
+mkdir -p n8n_data
 sudo chown -R 1000:1000 n8n_data
 docker-compose up -d


### PR DESCRIPTION
## Summary
- add strict error handling to install script
- ensure script runs from repo root by determining its directory
- create n8n_data dir safely

## Testing
- `bash -n scripts/install_n8n.sh`


------
https://chatgpt.com/codex/tasks/task_e_68401e72d27c8329be3d0582454d67ba