### PR TITLE
Fix Deploy button path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > One-click deployment of n8n on Oracle Cloud Free Tier.
 
-[![Deploy to Oracle Cloud](https://raw.githubusercontent.com/oracle/oci-cloudnative/deploy-button/docs/deploy-to-oracle-cloud.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/clementalo9/n8n_oci/archive/refs/heads/main.zip)
+[![Deploy to Oracle Cloud](https://github.com/clementalo9/n8n_oci/blob/main/img/Deploy%20to%20Oracle%20Cloud.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/clementalo9/n8n_oci/archive/refs/heads/main.zip)
 
 ## ✨ Features
 - Runs on VM.Standard.A1.Flex (ARM, free tier)


### PR DESCRIPTION
## Summary
- fix path to Deploy to Oracle Cloud button in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684026c9b5f0832991e771b50b354042