### PR TITLE
Fix Terraform file parse error

### DIFF
--- a/terraform/maint.tf
+++ b/terraform/maint.tf
@@ -1,4 +1,3 @@
-hcl
 provider "oci" {
   tenancy_ocid     = var.tenancy_ocid
   user_ocid        = var.user_ocid


### PR DESCRIPTION
## Summary
- remove stray `hcl` token at the start of maint.tf

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_684045865d64832993c4bb6628e6d534