### PR TITLE
Fix variable names for VM credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ terraform apply
 
 > Change them in `docker-compose.yml` after first deployment.
 
+### VM Credentials
+The Terraform variables `vm_admin_user` and `vm_admin_password` configure the SSH
+login for the created virtual machine.
+
 ## 🌐 Accessing n8n
 Go to `http://<your-instance-public-ip>:5678`
 

--- a/terraform/maint.tf
+++ b/terraform/maint.tf
@@ -80,8 +80,8 @@ resource "oci_core_instance" "n8n_instance" {
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
     user_data = base64encode(templatefile("${path.module}/../scripts/install_n8n.sh", {
-      n8n_user     = var.n8n_admin_user
-      n8n_password = var.n8n_admin_password
+      n8n_user     = var.vm_admin_user
+      n8n_password = var.vm_admin_password
     }))
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,15 @@
 
+variable "vm_admin_user" {
+  description = "Username for the VM SSH login"
+  type        = string
+}
+
+variable "vm_admin_password" {
+  description = "Password for the VM SSH login"
+  type        = string
+  sensitive   = true
+}
+
 variable "ssh_public_key" {
   description = "SSH Public Key"
   type        = string


### PR DESCRIPTION
## Summary
- rename admin variables to reflect VM authentication
- update Terraform to use new names
- document VM credential variables

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846acb334e88329a6d39a314a23d00e