### PR TITLE
Use templated credentials in install script

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -euo pipefail
+
+# Credentials for n8n basic auth are supplied by Terraform when rendering this
+# template. They replace the previously hard-coded values.
+N8N_BASIC_AUTH_USER="${n8n_user}"
+N8N_BASIC_AUTH_PASSWORD="${n8n_password}"
 sudo apt update && sudo apt install -y ca-certificates curl gnupg lsb-release
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
@@ -13,6 +18,8 @@ sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 cd "$SCRIPT_DIR/.."
+sudo sed -i "s/N8N_BASIC_AUTH_USER=.*/N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER}/" docker-compose.yml
+sudo sed -i "s/N8N_BASIC_AUTH_PASSWORD=.*/N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD}/" docker-compose.yml
 mkdir -p n8n_data
 sudo chown -R 1000:1000 n8n_data
 docker-compose up -d


### PR DESCRIPTION
## Summary
- allow credentials for n8n basic auth to be provided via template variables

## Testing
- `terraform -chdir=terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e40433fc8329bca51ef2be4a6390