### PR TITLE
Update README credentials and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Click the button above to deploy automatically in your Oracle tenancy.
 1. Log into your Oracle Cloud account
 2. Select your compartment
 3. Launch the stack and follow the prompts
+   (Resource Manager will ask for `vm_admin_user`, `vm_admin_password`,
+   and `ssh_public_key`)
 
 ## 🔧 Manual Deployment
 ```bash
@@ -40,13 +42,14 @@ terraform apply
 
 ## 🔐 Default Credentials
 - Username: `admin`
-- Password: `adminpassword`
+- Password: `strongpassword`
 
 > Change them in `docker-compose.yml` after first deployment.
 
 ### VM Credentials
-The Terraform variables `vm_admin_user` and `vm_admin_password` configure the SSH
-login for the created virtual machine.
+The Terraform variables `vm_admin_user`, `vm_admin_password`, and `ssh_public_key`
+configure the SSH login for the created virtual machine. OCI Resource Manager
+will prompt for these values when launching the stack.
 
 ## 🌐 Accessing n8n
 Go to `http://<your-instance-public-ip>:5678`
@@ -62,7 +65,6 @@ You need a domain name to use Let's Encrypt. We recommend [DuckDNS](https://www.
 
 ## 📜 License
 MIT
-```
 
 ---
 


### PR DESCRIPTION
## Summary
- fix Quick Deploy instructions
- update default credentials to match `docker-compose.yml`
- note which VM variables Oracle Cloud asks for
- clean up dangling code block and ensure newline

## Testing
- `bash -n scripts/install_n8n.sh`
- `docker-compose config -q` *(fails: command not found)*
- `terraform -help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e54b2740832999271d550c5a3fd9