### PR TITLE
Update Manual Deployment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ terraform init
 terraform apply
 ```
 
+### Tenancy OCID
+When running `terraform apply` manually, pass your tenancy OCID:
+
+```bash
+terraform apply -var "tenancy_ocid=<your-tenancy-ocid>"
+```
+
+Oracle Resource Manager sets this variable automatically when deploying via the console.
+
 ## 🔐 Default Credentials
 - Username: `admin`
 - Password: `strongpassword`


### PR DESCRIPTION
## Summary
- document tenancy ocid variable for manual terraform use

## Testing
- `terraform init -backend=false` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea774d2c8329b7b110342b1d7589