### PR TITLE
Fix sed replacement for credentials

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 # template. They replace the previously hard-coded values.
 N8N_BASIC_AUTH_USER="${n8n_user}"
 N8N_BASIC_AUTH_PASSWORD="${n8n_password}"
+
+# Escape special characters for sed replacement
+ESCAPED_USER=$(printf '%s' "$N8N_BASIC_AUTH_USER" | sed -e 's/[\/&|]/\\&/g')
+ESCAPED_PASSWORD=$(printf '%s' "$N8N_BASIC_AUTH_PASSWORD" | sed -e 's/[\/&|]/\\&/g')
 sudo apt update && sudo apt install -y ca-certificates curl gnupg lsb-release
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
@@ -18,8 +22,8 @@ sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 cd "$SCRIPT_DIR/.."
-sudo sed -i "s/N8N_BASIC_AUTH_USER=.*/N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER}/" docker-compose.yml
-sudo sed -i "s/N8N_BASIC_AUTH_PASSWORD=.*/N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD}/" docker-compose.yml
+sudo sed -i "s|N8N_BASIC_AUTH_USER=.*|N8N_BASIC_AUTH_USER=${ESCAPED_USER}|" docker-compose.yml
+sudo sed -i "s|N8N_BASIC_AUTH_PASSWORD=.*|N8N_BASIC_AUTH_PASSWORD=${ESCAPED_PASSWORD}|" docker-compose.yml
 mkdir -p n8n_data
 sudo chown -R 1000:1000 n8n_data
 docker-compose up -d


### PR DESCRIPTION
## Summary
- escape special characters in auth credentials
- update sed commands to use escaped variables

## Testing
- `shellcheck -e SC2154 -e SC2086 scripts/install_n8n.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846eba15d488329b8e51acb9444e5e7