### PR TITLE
Fix Terraform install script templating

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -42,8 +42,8 @@ services:
       - ./n8n_data:/home/node/.n8n
 EOF
 fi
-sudo sed -i "s|N8N_BASIC_AUTH_USER=.*|N8N_BASIC_AUTH_USER=${ESCAPED_USER}|" docker-compose.yml
-sudo sed -i "s|N8N_BASIC_AUTH_PASSWORD=.*|N8N_BASIC_AUTH_PASSWORD=${ESCAPED_PASSWORD}|" docker-compose.yml
+sudo sed -i "s|N8N_BASIC_AUTH_USER=.*|N8N_BASIC_AUTH_USER=$${ESCAPED_USER}|" docker-compose.yml
+sudo sed -i "s|N8N_BASIC_AUTH_PASSWORD=.*|N8N_BASIC_AUTH_PASSWORD=$${ESCAPED_PASSWORD}|" docker-compose.yml
 mkdir -p n8n_data
 sudo chown -R 1000:1000 n8n_data
 docker-compose up -d


### PR DESCRIPTION
## Summary
- escape shell variables so Terraform won't expect them

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: provider not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846f9be06e48329a38f8a18623a7321