### PR TITLE
Add image OCID variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ terraform apply -var "tenancy_ocid=<your-tenancy-ocid>"
 
 Oracle Resource Manager sets this variable automatically when deploying via the console.
 
+### Image OCID
+When running Terraform manually, you must also provide the OCID of an Ubuntu
+image compatible with your region:
+
+```bash
+terraform apply -var "image_ocid=<ocid>"
+```
+
+You can find available Ubuntu image OCIDs in the Oracle Cloud Console under
+"Images" for your chosen region.
+
 ## 🔐 Default Credentials
 - Username: `admin`
 - Password: `strongpassword`

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,6 +53,11 @@ resource "oci_core_instance" "n8n_instance" {
     ocpus         = 1
   }
 
+  source_details {
+    source_type = "image"
+    source_id   = var.image_ocid
+  }
+
   create_vnic_details {
     subnet_id        = oci_core_subnet.n8n_subnet.id
     assign_public_ip = true

--- a/terraform/schema.yml
+++ b/terraform/schema.yml
@@ -12,3 +12,8 @@
   title: SSH Public Key
   description: Paste your SSH public key to access the virtual machine via SSH
   required: true
+
+- name: image_ocid
+  title: Image OCID
+  description: OCID of the Ubuntu image to use
+  required: true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,3 +19,8 @@ variable "ssh_public_key" {
   type        = string
 }
 
+variable "image_ocid" {
+  description = "The OCID of the OS image to use for the VM"
+  type        = string
+}
+


### PR DESCRIPTION
## Summary
- add `image_ocid` variable
- prompt for the OCID in Resource Manager schema
- source VM from a provided image
- document using the variable in manual Terraform runs

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_684801ec1ef483299f83cf5fc9ba0d34