### PR TITLE
Fix OCI deployment errors

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -22,7 +22,7 @@ sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 
 # Create Docker Compose file with injected credentials
-cat <<EOF | sudo tee docker-compose.yml > /dev/null
+cat <<'EOF' | sudo tee docker-compose.yml > /dev/null
 services:
   n8n:
     image: n8nio/n8n
@@ -33,8 +33,8 @@ services:
     environment:
       - GENERIC_TIMEZONE=Europe/Madrid
       - N8N_BASIC_AUTH_ACTIVE=true
-      - N8N_BASIC_AUTH_USER=\$\${ESCAPED_USER}
-      - N8N_BASIC_AUTH_PASSWORD=\$\${ESCAPED_PASSWORD}
+      - N8N_BASIC_AUTH_USER=$${ESCAPED_USER}
+      - N8N_BASIC_AUTH_PASSWORD=$${ESCAPED_PASSWORD}
     volumes:
       - ./n8n_data:/home/node/.n8n
 EOF

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,7 +66,7 @@ resource "oci_core_instance" "n8n_instance" {
 
   source_details {
     source_type = "image"
-    image_id    = data.oci_core_images.oracle_linux.images[0].id
+    source_id   = data.oci_core_images.oracle_linux.images[0].id
   }
 
   create_vnic_details {


### PR DESCRIPTION
## Summary
- correct `oci_core_instance` field for source image
- fix template syntax in install script

## Testing
- `terraform` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498dd6b8ac83298b00062c4ed421c5