### PR TITLE
Open SSH port in Terraform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## ✨ Features
 - Runs on VM.Standard.A1.Flex (ARM, free tier)
 - Public IP access on port 5678
+- SSH access on port 22
 - Basic auth enabled out of the box
 - Deployable via Oracle Cloud Resource Manager or Terraform CLI
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,7 +26,7 @@ resource "oci_core_virtual_network" "n8n_vcn" {
   dns_label      = "n8nvcn"
 }
 
-# Security list allowing HTTP/HTTPS and n8n ports
+# Security list allowing SSH, HTTP/HTTPS and n8n ports
 resource "oci_core_security_list" "n8n_security" {
   compartment_id = local.compartment_ocid
   vcn_id         = oci_core_virtual_network.n8n_vcn.id
@@ -36,6 +36,16 @@ resource "oci_core_security_list" "n8n_security" {
     protocol         = "all"
     destination      = "0.0.0.0/0"
     destination_type = "CIDR_BLOCK"
+  }
+
+  ingress_security_rules {
+    protocol    = "6" # TCP
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    tcp_options {
+      min = 22
+      max = 22
+    }
   }
 
   ingress_security_rules {


### PR DESCRIPTION
## Summary
- allow SSH in OCI security list
- document SSH access in the README

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6849a064dfb4832999c06441d8723b40