### PR TITLE
Remove obsolete VM login vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Click the button above to deploy automatically in your Oracle tenancy.
 1. Log into your Oracle Cloud account
 2. Select your compartment
 3. Launch the stack and follow the prompts
-   (Resource Manager will ask for `vm_admin_user`, `vm_admin_password`,
-   and `ssh_public_key`)
+   (Resource Manager will ask for your `ssh_public_key`)
 
 ## 🔧 Manual Deployment
 ```bash
@@ -68,9 +67,8 @@ You can find available Ubuntu image OCIDs in the Oracle Cloud Console under
 > Change them in `docker-compose.yml` after first deployment.
 
 ### VM Credentials
-The Terraform variables `vm_admin_user`, `vm_admin_password`, and `ssh_public_key`
-configure the SSH login for the created virtual machine. OCI Resource Manager
-will prompt for these values when launching the stack.
+The virtual machine uses the default `opc` user with SSH key authentication.
+Provide your `ssh_public_key` when launching the stack to allow SSH access.
 
 ## 🌐 Accessing n8n
 Go to `http://<your-instance-public-ip>:5678`

--- a/terraform/schema.yml
+++ b/terraform/schema.yml
@@ -1,13 +1,3 @@
-- name: vm_admin_user
-  title: VM Admin Username
-  description: Username for the VM SSH login
-  required: true
-
-- name: vm_admin_password
-  title: VM Admin Password
-  description: Password for the VM SSH login
-  required: true
-
 - name: ssh_public_key
   title: SSH Public Key
   description: Paste your SSH public key to access the virtual machine via SSH


### PR DESCRIPTION
## Summary
- update README to mention only ssh key requirement
- drop `vm_admin_user` and `vm_admin_password` from schema

## Testing
- `terraform init -backend=false` *(fails: terraform command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3f9bd4c83299043faab9ab16c4e