### PR TITLE
Remove admin credentials from stack parameters

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Credentials injected by Terraform
-N8N_BASIC_AUTH_USER="__N8N_USER__"
-N8N_BASIC_AUTH_PASSWORD="__N8N_PASSWORD__"
-
-# Escape special characters
-ESCAPED_USER=$(printf '%s' "$N8N_BASIC_AUTH_USER" | sed -e 's/[\/&|]/\\&/g')
-ESCAPED_PASSWORD=$(printf '%s' "$N8N_BASIC_AUTH_PASSWORD" | sed -e 's/[\/&|]/\\&/g')
+# Default n8n credentials
+ESCAPED_USER="admin"
+ESCAPED_PASSWORD="strongpassword"
 
 # Install Docker and Docker Compose
 sudo apt update && sudo apt install -y ca-certificates curl gnupg lsb-release
@@ -21,7 +17,7 @@ sudo usermod -aG docker $USER
 sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
-# Create Docker Compose file with injected credentials
+# Create Docker Compose file with default credentials
 cat <<'EOF' | sudo tee docker-compose.yml > /dev/null
 services:
   n8n:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -130,10 +130,7 @@ resource "oci_core_instance" "n8n_instance" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = base64encode(templatefile("${path.module}/../scripts/install_n8n.sh", {
-      n8n_user     = var.n8n_admin_user,
-      n8n_password = var.n8n_admin_password
-    }))
+    user_data           = filebase64("${path.module}/../scripts/install_n8n.sh")
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,14 +8,3 @@ variable "ssh_public_key" {
   type        = string
 }
 
-variable "n8n_admin_user" {
-  description = "Instance username"
-  type        = string
-  sensitive   = true
-}
-
-variable "n8n_admin_password" {
-  description = "Instance password"
-  type        = string
-  sensitive   = true
-}


### PR DESCRIPTION
## Summary
- avoid exposing n8n admin user/password as stack variables
- embed default credentials directly in the install script
- simplify templatefile usage

## Testing
- `terraform init -backend=false` *(fails: failed to query available provider packages)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6849a6b2ecb883299c8b94b5cdb3e2fa