### PR TITLE
Remove opc user during VM setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Oracle Resource Manager sets this variable automatically when deploying via the 
 The stack automatically retrieves the latest **Ubuntu 22.04** image, so no image
 OCID needs to be provided when deploying manually.
 
+The provisioning script removes the default `opc` user if present so that only the
+`ubuntu` account remains for SSH access.
+
 ## 🔐 Default Credentials
 - Username: `admin`
 - Password: `strongpassword`

--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# Remove default opc user if present
+if id "opc" &>/dev/null; then
+  sudo userdel -r opc
+fi
+
 # Default n8n credentials
 ESCAPED_USER="admin"
 ESCAPED_PASSWORD="strongpassword"


### PR DESCRIPTION
## Summary
- remove the default `opc` user in the install script
- document that the provisioning script removes `opc`

## Testing
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a92996f8483299cbe3aabfb8d97ed