### PR TITLE
Simplify deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,68 +31,13 @@ You can use the button below to provision the instance and network infrastructur
 
 [![Deploy to Oracle Cloud](https://github.com/clementalo9/oke_A1/raw/main/images/Deploy2OCI.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/clementalo9/n8n_oci/archive/refs/heads/main.zip)
 
----
+Terraform provisions the VM, installs Docker, and launches n8n automatically via
+[`scripts/install_n8n.sh`](scripts/install_n8n.sh). The script defines the
+`N8N_BASIC_AUTH_USER` and `N8N_BASIC_AUTH_PASSWORD` variables used for basic
+authentication. Edit these values in the script before applying the stack if you
+want custom credentials.
 
-## 🔧 After Deployment: Connect to Your Instance
-
-1. Go to the **Compute > Instances** section in the OCI console.
-2. Copy the public IP of your instance.
-3. Use your SSH key to connect via terminal or PuTTY:
-
-### 🖥️ From Terminal (Linux/macOS)
-
-```bash
-ssh -i path/to/your/private.key opc@YOUR_PUBLIC_IP
-```
-
-> Replace `path/to/your/private.key` with the path to your private SSH key used during deployment.
-
----
-
-## 🐳 Install Docker & Docker Compose
-
-Once connected to your instance:
-
-```bash
-sudo apt update && sudo apt install docker.io docker-compose -y
-sudo systemctl enable docker --now
-sudo usermod -aG docker $USER
-newgrp docker
-```
-
----
-
-## 📂 Create the n8n Directory and Files
-
-```bash
-mkdir ~/n8n && cd ~/n8n
-nano docker-compose.yml
-```
-
-Paste this content into `docker-compose.yml`:
-
-```yaml
-version: "3"
-
-services:
-  n8n:
-    image: n8nio/n8n
-    restart: always
-    ports:
-      - "5678:5678"
-    environment:
-      - N8N_BASIC_AUTH_ACTIVE=true
-      - N8N_BASIC_AUTH_USER=admin
-      - N8N_BASIC_AUTH_PASSWORD=your_secure_password
-    volumes:
-      - ~/.n8n:/home/node/.n8n
-```
-
-Save and exit. Then launch:
-
-```bash
-docker compose up -d
-```
+Once deployment completes, continue below to access your n8n editor.
 
 ---
 
@@ -104,7 +49,9 @@ docker compose up -d
 http://YOUR_PUBLIC_IP:5678
 ```
 
-> You will be prompted for the login and password defined in `docker-compose.yml`.
+> You will be prompted for the credentials defined in
+> [`scripts/install_n8n.sh`](scripts/install_n8n.sh) and written to
+> `docker-compose.yml`.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove manual SSH and Docker setup sections from README
- explain that Terraform provisions the VM, installs Docker and starts n8n
- show how to adjust login credentials via `scripts/install_n8n.sh`

## Testing
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504413b33883299a63c8b84a41b4b1