### PR TITLE
Handle undefined USER in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Terraform provisions the VM, installs Docker, and launches n8n automatically via
 `N8N_BASIC_AUTH_USER` and `N8N_BASIC_AUTH_PASSWORD` variables used for basic
 authentication. Edit these values in the script before applying the stack if you
 want custom credentials.
+The script also checks whether the `USER` environment variable is set before
+attempting to add the user to the Docker group, preventing failures in
+non-interactive shells.
 
 ## 🔌 Ports Opened by Terraform
 

--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -17,7 +17,9 @@ echo \
   https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt update && sudo apt install -y docker-ce docker-ce-cli containerd.io
-sudo usermod -aG docker $USER
+if [ -n "${USER-}" ]; then
+    sudo usermod -aG docker "$USER"
+fi
 sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 


### PR DESCRIPTION
## Summary
- gracefully handle `USER` being undefined in `install_n8n.sh`
- mention this behavior in the README

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_685051621e24832984fe845201fa74b5