### PR TITLE
Remove unused VM admin user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ You can review these rules in [`terraform/main.tf`](terraform/main.tf) inside th
 
 Once deployment completes, continue below to access your n8n editor.
 
+To connect via SSH, use the default **ubuntu** user with the same key you provided during stack creation:
+
+```bash
+ssh ubuntu@YOUR_PUBLIC_IP
+```
+
 ---
 
 ## 🌐 Access Your n8n Editor

--- a/terraform/schema.yml
+++ b/terraform/schema.yml
@@ -1,13 +1,3 @@
-- name: vm_admin_user
-  title: VM Admin Username
-  description: Username for the VM SSH login
-  required: true
-
-- name: vm_admin_password
-  title: VM Admin Password
-  description: Password for the VM SSH login
-  required: true
-
 - name: ssh_public_key
   title: SSH Public Key
   description: Paste your SSH public key to access the virtual machine via SSH


### PR DESCRIPTION
## Summary
- remove unused VM admin user/password fields from Terraform schema
- document default ubuntu SSH user

## Testing
- `terraform fmt -check terraform/variables.tf terraform/main.tf`
- `terraform validate terraform` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_6850516b267483298d01a13eb3ffcd40