### PR TITLE
Add note about deployment directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ http://YOUR_PUBLIC_IP:5678
 > You will be prompted for the credentials defined in
 > [`scripts/install_n8n.sh`](scripts/install_n8n.sh) and written to
 > `docker-compose.yml`.
+> **Note:** During automatic deployment the script runs from the root user's home directory, so `docker-compose.yml` and the `n8n_data/` folder will be inside `/root`.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that auto-deploy script runs from root's home

## Testing
- `terraform fmt -check terraform/*.tf` *(fails: terraform not installed)*
- `shellcheck scripts/install_n8n.sh` *(fails: shellcheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685051715b2c83299eb0c0a9d1f0621e