### PR TITLE
Ensure docker-compose runs from home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ http://YOUR_PUBLIC_IP:5678
 > You will be prompted for the credentials defined in
 > [`scripts/install_n8n.sh`](scripts/install_n8n.sh) and written to
 > `docker-compose.yml`.
-> **Note:** During automatic deployment the script runs from the root user's home directory, so `docker-compose.yml` and the `n8n_data/` folder will be inside `/root`.
+> **Note:** During automatic deployment the script changes to the root user's home directory, so `docker-compose.yml` and the `n8n_data/` folder will be inside `/root`.
 
 ---
 

--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # Credentials injected by Terraform
 N8N_BASIC_AUTH_USER="__N8N_USER__"
 N8N_BASIC_AUTH_PASSWORD="__N8N_PASSWORD__"
+# Ensure all files are created in the user's home directory
+cd "$HOME"
 
 # Escape special characters
 ESCAPED_USER=$(printf '%s' "$N8N_BASIC_AUTH_USER" | sed -e 's/[\/&|]/\\&/g')
@@ -44,4 +46,4 @@ EOF
 # Prepare volume and start container
 mkdir -p n8n_data
 sudo chown -R 1000:1000 n8n_data
-sudo docker-compose up -d
+sudo docker-compose -p n8n up -d


### PR DESCRIPTION
## Summary
- run install script from `$HOME` to reliably place files
- specify docker compose project name
- clarify README note about running from root's home

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505644b82c832989da7ae035613576