### PR TITLE
Update install script variable expansion

### DIFF
--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -26,7 +26,7 @@ sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 
 # Create Docker Compose file with injected credentials
-cat <<'EOF' | sudo tee docker-compose.yml > /dev/null
+cat <<EOF | sudo tee docker-compose.yml > /dev/null
 services:
   n8n:
     image: n8nio/n8n
@@ -37,8 +37,8 @@ services:
     environment:
       - GENERIC_TIMEZONE=Europe/Madrid
       - N8N_BASIC_AUTH_ACTIVE=true
-      - N8N_BASIC_AUTH_USER=$${ESCAPED_USER}
-      - N8N_BASIC_AUTH_PASSWORD=$${ESCAPED_PASSWORD}
+      - N8N_BASIC_AUTH_USER=$ESCAPED_USER
+      - N8N_BASIC_AUTH_PASSWORD=$ESCAPED_PASSWORD
     volumes:
       - ./n8n_data:/home/node/.n8n
 EOF


### PR DESCRIPTION
## Summary
- allow variable interpolation in install script's Docker Compose snippet
- output variables without escaping dollar signs

## Testing
- `bash install_n8n.sh`

------
https://chatgpt.com/codex/tasks/task_e_68509421d79c832991f79fd987ba0567