### PR TITLE
Update NGINX config example

### DIFF
--- a/docs/nginx-ssl.md
+++ b/docs/nginx-ssl.md
@@ -38,11 +38,14 @@ Create `/etc/nginx/sites-available/n8n` with the following content
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    root /var/www/html;
-    index index.html index.htm index.nginx-debian.html;
     server_name _;
     location / {
-        try_files $uri $uri/ =404;
+        proxy_pass http://localhost:5678;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
     }
 }
 ```


### PR DESCRIPTION
## Summary
- update the sample NGINX configuration in `docs/nginx-ssl.md` to use a reverse proxy for n8n on port 5678

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68527c4fa214832993304f8bb670d682