### PR TITLE
Add N8N_SECURE_COOKIE flag and note on SSL cleanup

### DIFF
--- a/docs/nginx-ssl.md
+++ b/docs/nginx-ssl.md
@@ -97,6 +97,10 @@ If you previously enabled Basic Auth in your `docker-compose.yml`,
 remove the `N8N_BASIC_AUTH_*` lines so that n8n can manage
 authentication via its own login page.
 
+If you also set `N8N_SECURE_COOKIE=false` to allow logins over plain HTTP,
+remove that line after obtaining the certificate so that cookies are marked
+secure.
+
 Recreate the container after editing:
 
 ```bash

--- a/scripts/install_n8n.sh
+++ b/scripts/install_n8n.sh
@@ -39,6 +39,7 @@ services:
       - N8N_BASIC_AUTH_ACTIVE=true
       - N8N_BASIC_AUTH_USER=$ESCAPED_USER
       - N8N_BASIC_AUTH_PASSWORD=$ESCAPED_PASSWORD
+      - N8N_SECURE_COOKIE=false
     volumes:
       - ./n8n_data:/home/node/.n8n
 EOF


### PR DESCRIPTION
## Summary
- enable insecure cookies during initial install
- document removing `N8N_SECURE_COOKIE` after adding HTTPS

## Testing
- `bash -n scripts/install_n8n.sh`
- ❌ `terraform validate` *(failed: `terraform: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852832824788329b2b08f7d5e31303c