### PR TITLE
docs: update instructions for first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ ssh -i /path/to/private/key ubuntu@YOUR_PUBLIC_IP
 - Go to your browser and open:
 
 ```
-http://YOUR_PUBLIC_IP:5678
+ http://YOUR_PUBLIC_IP:5678
 ```
 
-> You will be prompted for the credentials defined in
-> [`scripts/install_n8n.sh`](scripts/install_n8n.sh) and written to
-> `docker-compose.yml`.
+> On first run, n8n redirects to
+> `http://YOUR_PUBLIC_IP:5678/setup` where you can create your own credentials.
 > **Note:** During automatic deployment the script changes to the root user's home directory, so `docker-compose.yml` and the `n8n_data/` folder will be inside `/root`.
 
 ---


### PR DESCRIPTION
## Summary
- clarify README to use the `/setup` wizard to create credentials

## Testing
- `grep -n setup README.md`


------
https://chatgpt.com/codex/tasks/task_e_685284a8a7d08329b9da590fae88eb08